### PR TITLE
gpgme: fix compilation with musl 1.2.4

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
 PKG_VERSION:=1.18.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
@@ -51,6 +51,10 @@ CONFIGURE_ARGS += \
 	--disable-gpgsm-test \
 	--disable-g13-test \
 	--enable-languages="cpp"
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/gpgme++


### PR DESCRIPTION
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces so just having _GNU_SOURCE defined is not enough anymore.

Manually pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
