### PR TITLE
packages: gpgme and libassuan GPL version correction

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -9,8 +9,8 @@ PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
 PKG_HASH:=361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-PKG_LICENSE:=GPL-3.0-or-later
-PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING.LESSER
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1

--- a/libs/libassuan/Makefile
+++ b/libs/libassuan/Makefile
@@ -9,8 +9,8 @@ PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
 PKG_HASH:=8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-PKG_LICENSE:=GPL-3.0-or-later
-PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING.LIB
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Changed GPL version for gpgme and libassuan packages from GPLv3.0 to LGPLv2.1
previous wrong PR(https://github.com/kn-gl/packages/pull/4)

References: OWF-2685