### PR TITLE
net/curl: Added config option to enable c-ares

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -123,6 +123,10 @@ config LIBCURL_LIBIDN2
 	bool "Enable IDN2 support"
 	default n
 
+config LIBCURL_CARES
+	bool "Enable c-ares for DNS lookups"
+	default n
+
 config LIBCURL_THREADED_RESOLVER
 	bool "Enable threaded DNS resolver"
 	default n

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -96,6 +96,7 @@ define Package/libcurl
   DEPENDS:= +LIBCURL_WOLFSSL:libwolfssl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
   DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_ZSTD:libzstd +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap
   DEPENDS += +LIBCURL_LIBIDN2:libidn2 +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
+  DEPENDS += +LIBCURL_CARES:libcares
   TITLE:=A client-side URL transfer library
   MENU:=1
   ABI_VERSION:=4
@@ -111,7 +112,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += \
 	--disable-debug \
-	--disable-ares \
+	$(if $(CONFIG_LIBCURL_CARES),--enable-ares,--disable-ares) \
 	--enable-shared \
 	--enable-static \
 	--disable-manual \


### PR DESCRIPTION
Added new config option to enable c-ares as DNS backend in libcurl (disabled by default).

We need c-ares enabled to be able to set `CURLOPT_DNS_INTERFACE`

Related PR:
- https://github.com/kn-gl/feed_prpl/pull/237
- https://github.com/kn-gl/prplos/pull/170

Reference: [BETA-1862](https://jira.kaonmedia.com/browse/BETA-1862)